### PR TITLE
Add simple task management

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,17 @@ class ConversationResponse(BaseModel):
     model_name: str
     created_at: str
 
+class TaskCreate(BaseModel):
+    title: str
+    description: Optional[str] = ''
+
+class TaskResponse(BaseModel):
+    id: int
+    title: str
+    description: Optional[str]
+    status: str
+    created_at: str
+
 @app.post("/api/chat")
 async def chat(chat_message: ChatMessage):
     try:
@@ -55,6 +66,55 @@ async def get_conversations(limit: int = 100):
             }
             for conv in conversations
         ]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/api/tasks", response_model=TaskResponse)
+async def create_task(task: TaskCreate):
+    try:
+        task_id = await db.create_task(task.title, task.description)
+        new_task = await db.get_task(task_id)
+        return {
+            "id": new_task[0],
+            "title": new_task[1],
+            "description": new_task[2],
+            "status": new_task[3],
+            "created_at": new_task[4]
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/tasks", response_model=List[TaskResponse])
+async def get_tasks():
+    try:
+        tasks = await db.get_tasks()
+        return [
+            {
+                "id": t[0],
+                "title": t[1],
+                "description": t[2],
+                "status": t[3],
+                "created_at": t[4]
+            }
+            for t in tasks
+        ]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.put("/api/tasks/{task_id}", response_model=TaskResponse)
+async def update_task(task_id: int, status: str):
+    try:
+        updated = await db.update_task_status(task_id, status)
+        return {
+            "id": updated[0],
+            "title": updated[1],
+            "description": updated[2],
+            "status": updated[3],
+            "created_at": updated[4]
+        }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/models/database.py
+++ b/models/database.py
@@ -17,6 +17,15 @@ class Database:
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         ''')
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            description TEXT,
+            status TEXT DEFAULT 'todo',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        ''')
         self.conn.commit()
         
     async def save_conversation(self, user_message: str, assistant_message: str, model_name: str):
@@ -30,8 +39,42 @@ class Database:
     async def get_conversations(self, limit: int = 100):
         cursor = self.conn.cursor()
         cursor.execute('''
-        SELECT * FROM conversations 
-        ORDER BY created_at DESC 
+        SELECT * FROM conversations
+        ORDER BY created_at DESC
         LIMIT ?
         ''', (limit,))
-        return cursor.fetchall() 
+        return cursor.fetchall()
+
+    async def create_task(self, title: str, description: str = '', status: str = 'todo'):
+        cursor = self.conn.cursor()
+        cursor.execute('''
+        INSERT INTO tasks (title, description, status)
+        VALUES (?, ?, ?)
+        ''', (title, description, status))
+        self.conn.commit()
+        return cursor.lastrowid
+
+    async def get_tasks(self):
+        cursor = self.conn.cursor()
+        cursor.execute('''
+        SELECT id, title, description, status, created_at
+        FROM tasks
+        ORDER BY created_at DESC
+        ''')
+        return cursor.fetchall()
+
+    async def get_task(self, task_id: int):
+        cursor = self.conn.cursor()
+        cursor.execute('''
+        SELECT id, title, description, status, created_at
+        FROM tasks WHERE id = ?
+        ''', (task_id,))
+        return cursor.fetchone()
+
+    async def update_task_status(self, task_id: int, status: str):
+        cursor = self.conn.cursor()
+        cursor.execute('''
+        UPDATE tasks SET status = ? WHERE id = ?
+        ''', (status, task_id))
+        self.conn.commit()
+        return await self.get_task(task_id)

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,10 @@
           <button class="history-btn" @click="showHistory = true">
             历史记录
           </button>
-          <ModelSelector 
+          <button class="history-btn" @click="showTasks = true">
+            任务管理
+          </button>
+          <ModelSelector
             :models="availableModels"
             v-model="selectedModel"
           />
@@ -34,9 +37,13 @@
         </button>
       </div>
     </div>
-    <HistoryPanel 
+    <HistoryPanel
       :is-open="showHistory"
       @close="closeHistory"
+    />
+    <TaskPanel
+      :is-open="showTasks"
+      @close="closeTasks"
     />
   </div>
 </template>
@@ -46,13 +53,15 @@ import { ref } from 'vue'
 import ChatWindow from './components/ChatWindow.vue'
 import ModelSelector from './components/ModelSelector.vue'
 import HistoryPanel from './components/HistoryPanel.vue'
+import TaskPanel from './components/TaskPanel.vue'
 import { sendChatMessage } from './services/api'
 
 export default {
   components: {
     ChatWindow,
     ModelSelector,
-    HistoryPanel
+    HistoryPanel,
+    TaskPanel
   },
   setup() {
     const messages = ref([])
@@ -65,6 +74,7 @@ export default {
       { id: 'wenxin', name: '文心一言' }
     ])
     const showHistory = ref(false)
+    const showTasks = ref(false)
 
     const sendMessage = async () => {
       if (!userInput.value.trim() || loading.value) return
@@ -103,6 +113,10 @@ export default {
       showHistory.value = false
     }
 
+    const closeTasks = () => {
+      showTasks.value = false
+    }
+
     return {
       messages,
       userInput,
@@ -111,7 +125,9 @@ export default {
       availableModels,
       sendMessage,
       showHistory,
-      closeHistory
+      closeHistory,
+      showTasks,
+      closeTasks
     }
   }
 }

--- a/src/components/TaskPanel.vue
+++ b/src/components/TaskPanel.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="task-panel" :class="{ 'is-open': isOpen }">
+    <div class="task-header">
+      <h2>任务管理</h2>
+      <button class="close-btn" @click="handleClose" title="关闭">×</button>
+    </div>
+    <div class="task-content">
+      <form class="new-task-form" @submit.prevent="createNewTask">
+        <input v-model="newTitle" placeholder="任务标题" required />
+        <input v-model="newDesc" placeholder="任务描述" />
+        <button type="submit">添加</button>
+      </form>
+      <div v-if="loading" class="loading">加载中...</div>
+      <div v-else-if="tasks.length === 0" class="empty">暂无任务</div>
+      <ul v-else class="task-list">
+        <li v-for="task in tasks" :key="task.id" class="task-item">
+          <div class="task-main">
+            <span class="task-title">{{ task.title }}</span>
+            <span class="task-status">{{ task.status }}</span>
+          </div>
+          <div class="task-desc">{{ task.description }}</div>
+          <button v-if="task.status !== 'done'" @click="markDone(task.id)">完成</button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue'
+import { createTask, getTasks, updateTaskStatus } from '../services/api'
+
+export default {
+  props: {
+    isOpen: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['close'],
+  setup(props, { emit }) {
+    const tasks = ref([])
+    const loading = ref(false)
+    const newTitle = ref('')
+    const newDesc = ref('')
+
+    const handleClose = () => {
+      emit('close')
+    }
+
+    const loadTasks = async () => {
+      loading.value = true
+      try {
+        tasks.value = await getTasks()
+      } catch (e) {
+        console.error('加载任务失败', e)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    const createNewTask = async () => {
+      if (!newTitle.value.trim()) return
+      try {
+        const task = await createTask({ title: newTitle.value, description: newDesc.value })
+        tasks.value.unshift(task)
+        newTitle.value = ''
+        newDesc.value = ''
+      } catch (e) {
+        console.error('创建任务失败', e)
+      }
+    }
+
+    const markDone = async (id) => {
+      try {
+        const task = await updateTaskStatus(id, 'done')
+        const index = tasks.value.findIndex(t => t.id === id)
+        if (index > -1) tasks.value[index] = task
+      } catch (e) {
+        console.error('更新任务状态失败', e)
+      }
+    }
+
+    onMounted(() => {
+      loadTasks()
+    })
+
+    return { tasks, loading, newTitle, newDesc, handleClose, createNewTask, markDone }
+  }
+}
+</script>
+
+<style scoped>
+.task-panel {
+  position: fixed;
+  top: 0;
+  right: -400px;
+  width: 400px;
+  height: 100vh;
+  background: white;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  transition: right 0.3s ease;
+  z-index: 1000;
+}
+
+.task-panel.is-open {
+  right: 0;
+}
+
+.task-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  color: #666;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+  background-color: #f3f4f6;
+  color: #1f2937;
+}
+
+.task-content {
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.new-task-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.new-task-form input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.new-task-form button {
+  padding: 0.5rem 1rem;
+  background: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.task-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.task-item {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.task-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.task-title {
+  font-weight: bold;
+}
+
+.task-status {
+  font-size: 0.875rem;
+  color: var(--primary-color);
+}
+
+.task-desc {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+  color: #555;
+}
+
+.task-item button {
+  padding: 0.25rem 0.75rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.task-item button:hover {
+  opacity: 0.9;
+}
+
+.loading, .empty {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+</style>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -27,4 +27,34 @@ export const getConversations = async () => {
     console.error('API Error:', error)
     throw error
   }
-} 
+}
+
+export const createTask = async (payload) => {
+  try {
+    const response = await api.post('/tasks', payload)
+    return response.data
+  } catch (error) {
+    console.error('API Error:', error)
+    throw error
+  }
+}
+
+export const getTasks = async () => {
+  try {
+    const response = await api.get('/tasks')
+    return response.data
+  } catch (error) {
+    console.error('API Error:', error)
+    throw error
+  }
+}
+
+export const updateTaskStatus = async (id, status) => {
+  try {
+    const response = await api.put(`/tasks/${id}`, null, { params: { status } })
+    return response.data
+  } catch (error) {
+    console.error('API Error:', error)
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- add TaskPanel component and include it in the app
- support tasks in backend DB and API
- expose task API functions in frontend services
- show task management button in the header

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: esbuild for another platform)*

------
https://chatgpt.com/codex/tasks/task_e_6841414e1f208321a0ed2161b19213da